### PR TITLE
Enable Hackage compatibility in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -9,3 +9,4 @@ extra-deps:
 #- Crypto-4.2.5.1
 #- text-1.2.2.1
 resolver: lts-6.15
+pvp-bounds: both


### PR DESCRIPTION
By providing more accurate meta-data this should help fix the build failures at
https://hackage.haskell.org/package/krapsh-0.1.6.0/reports/
as well as generally keep users from running into compile errors.

Moreover, the `description` ("Please see README.md") is not a proper description for your package (and Hackage will show a link to the README at the end of the description *if* the README exists; therefore that phrase is redundant), and hence this will cause poor experience for users (NB: your package won't be properly indexed by Hackage's package search feature and thus hurt its discoverability). See also [this posting](https://mail.haskell.org/pipermail/haskell-cafe/2016-November/125541.html) for more details.